### PR TITLE
config: add proxy for local backend

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,11 @@ export default defineConfig(({ mode }) => {
     server: {
       port: 3000,
       host: '0.0.0.0',
+      proxy: {
+        '/generate': 'http://127.0.0.1:8000',
+        '/health': 'http://127.0.0.1:8000',
+        '/preview': 'http://127.0.0.1:8000',
+      }
     },
     plugins: [react()],
     define: {


### PR DESCRIPTION

---

### Pourquoi cette PR ?

En local, quand on lance le frontend avec **Vite (port 3000)**, l’UI envoie des requêtes API en **URL relative** (ex: `/generate`, `/health`, `/preview/...`).
Sans proxy, ces requêtes partent sur `http://localhost:3000/...` au lieu d’aller sur le backend FastAPI (`http://127.0.0.1:8000`), donc la génération d’image échoue en mode dev.

### Ce que change cette PR

* Ajout d’un **proxy Vite** dans `vite.config.ts`
* Redirection des routes API vers `http://127.0.0.1:8000` :

  * `/generate`
  * `/health`
  * `/preview`

### Impact

* ✅ **Aucun impact UI / prod** (c’est uniquement pour le confort de dev local)
* ✅ Permet de relancer les tests d’image depuis l’UI en local (Vite ↔ FastAPI)

### Comment tester

1. Lancer le backend : `uvicorn api:app --reload --host 0.0.0.0 --port 8000`
2. Lancer le frontend : `npm run dev`
3. Depuis l’UI, déclencher une génération : la requête `/generate` passe bien via le proxy vers `:8000`.

---

#6 
