### PR TITLE
feat(#15): multi-style image generation system

### DIFF
--- a/engine/domain.py
+++ b/engine/domain.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Dict, Any
 from pydantic import BaseModel, Field, ConfigDict
 
 class Origin(BaseModel):
@@ -43,6 +43,9 @@ class MythologicalEntity(BaseModel):
     appearance: Appearance
     story: Story
     relations: Relations
+    # Contract V2 fields
+    type_specific: Optional[Dict[str, Any]] = None
+    rendering: Optional[Dict[str, Any]] = None
 
 class ImageGenerationRequest(BaseModel):
     entity_name: str

--- a/engine/orchestrator.py
+++ b/engine/orchestrator.py
@@ -22,9 +22,21 @@ class ImageOrchestrator:
         missing = self.get_missing_images()
         return len(self.data), len(missing)
     
-    def get_prompt_preview(self, entity_name: str) -> str:
-        """Returns the prompt for a specific entity."""
+    def get_prompt_preview(self, entity_name: str, style_id: str = "photoreal") -> str:
+        """Returns the prompt for a specific entity and style."""
         for entity in self.data:
             if entity.name.lower() == entity_name.lower():
-                return entity.appearance.image_generation_prompt
+                # Photoreal: use rendering.prompt_canon or fallback to legacy
+                if style_id == "photoreal":
+                    if entity.rendering and entity.rendering.get("prompt_canon"):
+                        return entity.rendering["prompt_canon"]
+                    return entity.appearance.image_generation_prompt
+                
+                # Other styles: lookup in prompt_variants
+                if entity.rendering and entity.rendering.get("prompt_variants"):
+                    for variant in entity.rendering["prompt_variants"]:
+                        if variant.get("style_id") == style_id and variant.get("prompt"):
+                            return variant["prompt"]
+                
+                return ""  # Empty prompt for unavailable style
         return "Entity not found."

--- a/src/components/StyleSelector.tsx
+++ b/src/components/StyleSelector.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+export interface StyleOption {
+    id: string;
+    label: string;
+    hasPrompt: boolean;
+}
+
+interface StyleSelectorProps {
+    styles: StyleOption[];
+    selectedStyle: string;
+    onSelectStyle: (styleId: string) => void;
+    imagesMap?: Record<string, string>;
+}
+
+const StyleSelector: React.FC<StyleSelectorProps> = ({
+    styles,
+    selectedStyle,
+    onSelectStyle,
+    imagesMap
+}) => {
+    return (
+        <div className="flex flex-wrap gap-2">
+            {styles.map((style) => {
+                const isSelected = style.id === selectedStyle;
+                const hasImage = imagesMap && imagesMap[style.id];
+                const isDisabled = !style.hasPrompt;
+
+                return (
+                    <button
+                        key={style.id}
+                        onClick={() => !isDisabled && onSelectStyle(style.id)}
+                        disabled={isDisabled}
+                        className={`
+              relative px-3 py-1.5 text-xs font-mono uppercase tracking-wider rounded-sm border transition-all
+              ${isSelected
+                                ? 'bg-amber-600 text-stone-900 border-amber-500 font-bold'
+                                : isDisabled
+                                    ? 'bg-stone-900/50 text-stone-600 border-stone-800 cursor-not-allowed opacity-50'
+                                    : 'bg-stone-900 text-stone-400 border-stone-700 hover:border-amber-500/50 hover:text-amber-200'
+                            }
+            `}
+                        title={isDisabled ? 'No prompt available' : style.label}
+                    >
+                        {style.label}
+                        {hasImage && (
+                            <span className="absolute -top-1 -right-1 w-2 h-2 bg-green-500 rounded-full border border-stone-900" title="Image generated" />
+                        )}
+                    </button>
+                );
+            })}
+        </div>
+    );
+};
+
+export default StyleSelector;

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,7 @@ export interface RenderingSpecific {
     label: string;
     prompt: string;
   }>;
+  images?: Record<string, string>;  // Map of style_id -> image URL
 }
 
 export interface MythologicalEntity {


### PR DESCRIPTION
Backend:
- domain.py: Add rendering + type_specific fields to MythologicalEntity
- orchestrator.py: Style-aware get_prompt_preview (prompt_canon + variants)
- api.py: Accept style_id, save to rendering.images[style_id]

Frontend:
- types.ts: Add images map to RenderingSpecific
- StyleSelector.tsx: New component for style selection
- EntityCard.tsx: Full multi-style integration with immediate image display

Closes #15