### PR TITLE
[codex] add smart UI for regional style

### DIFF
--- a/src/components/EntityCard.tsx
+++ b/src/components/EntityCard.tsx
@@ -29,6 +29,8 @@ const EntityCard: React.FC<EntityCardProps> = ({ data, onSelectEntity, onOpenLin
   const [generationState, setGenerationState] = useState<'idle' | 'generating' | 'completed' | 'error'>('idle');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [selectedStyle, setSelectedStyle] = useState('photoreal');
+  const [regionalPrompt, setRegionalPrompt] = useState('');
+  const [regionalPromptStatus, setRegionalPromptStatus] = useState<'loading' | 'available' | 'unavailable'>('loading');
 
   // Local state to track newly generated images (for immediate display before data refresh)
   const [generatedImages, setGeneratedImages] = useState<Record<string, string>>({});
@@ -36,9 +38,57 @@ const EntityCard: React.FC<EntityCardProps> = ({ data, onSelectEntity, onOpenLin
   // Track failed image URLs to prevent infinite load loops and allow fallback to generation view
   const [failedImages, setFailedImages] = useState<Set<string>>(new Set());
 
+  useEffect(() => {
+    const controller = new AbortController();
+
+    setRegionalPrompt('');
+    setRegionalPromptStatus('loading');
+
+    const loadRegionalPreview = async () => {
+      try {
+        const response = await fetch(
+          `/preview/${encodeURIComponent(data.name)}?style_id=regional_or_ethnic`,
+          { signal: controller.signal },
+        );
+
+        if (!response.ok) {
+          throw new Error('Regional preview unavailable');
+        }
+
+        const result = await response.json();
+        const prompt = typeof result.prompt === 'string' ? result.prompt.trim() : '';
+
+        setRegionalPrompt(prompt);
+        setRegionalPromptStatus(prompt ? 'available' : 'unavailable');
+      } catch (error) {
+        if (
+          controller.signal.aborted ||
+          (error instanceof DOMException && error.name === 'AbortError')
+        ) {
+          return;
+        }
+
+        setRegionalPrompt('');
+        setRegionalPromptStatus('unavailable');
+      }
+    };
+
+    loadRegionalPreview();
+
+    return () => controller.abort();
+  }, [data.name]);
+
   // Derive available styles with prompt availability
   const availableStyles: StyleOption[] = useMemo(() => {
-    return STYLE_DEFINITIONS.map(def => {
+    return STYLE_DEFINITIONS.flatMap(def => {
+      if (def.id === 'regional_or_ethnic') {
+        if (regionalPromptStatus !== 'available') {
+          return [];
+        }
+
+        return [{ ...def, hasPrompt: true }];
+      }
+
       let hasPrompt = false;
       if (def.id === 'photoreal') {
         hasPrompt = !!(data.rendering?.prompt_canon || data.appearance.image_generation_prompt);
@@ -46,9 +96,9 @@ const EntityCard: React.FC<EntityCardProps> = ({ data, onSelectEntity, onOpenLin
         const variant = data.rendering?.prompt_variants?.find(v => v.style_id === def.id);
         hasPrompt = !!(variant?.prompt);
       }
-      return { ...def, hasPrompt };
+      return [{ ...def, hasPrompt }];
     });
-  }, [data]);
+  }, [data, regionalPromptStatus]);
 
   // Derive current image URL: check local state first, then data.rendering.images, then legacy
   const currentImageUrl = useMemo(() => {
@@ -77,12 +127,16 @@ const EntityCard: React.FC<EntityCardProps> = ({ data, onSelectEntity, onOpenLin
 
   // Derive prompt for current style
   const currentPrompt = useMemo(() => {
+    if (selectedStyle === 'regional_or_ethnic') {
+      return regionalPrompt;
+    }
+
     if (selectedStyle === 'photoreal') {
       return data.rendering?.prompt_canon || data.appearance.image_generation_prompt || '';
     }
     const variant = data.rendering?.prompt_variants?.find(v => v.style_id === selectedStyle);
     return variant?.prompt || '';
-  }, [data, selectedStyle]);
+  }, [data, selectedStyle, regionalPrompt]);
 
   // Combine persisted + local images for indicator dots
   const allImagesMap = useMemo(() => {
@@ -108,6 +162,12 @@ const EntityCard: React.FC<EntityCardProps> = ({ data, onSelectEntity, onOpenLin
     // If no image exists, !currentImageUrl is true, and 'idle' makes the overlay visible.
     setGenerationState('idle');
   }, [selectedStyle]);
+
+  useEffect(() => {
+    if (selectedStyle === 'regional_or_ethnic' && regionalPromptStatus !== 'available') {
+      setSelectedStyle('photoreal');
+    }
+  }, [regionalPromptStatus, selectedStyle]);
 
   const handleGenerate = async () => {
     // Capture style at start of generation to avoid race conditions if user switches style while waiting

--- a/src/components/__tests__/EntityCard.test.tsx
+++ b/src/components/__tests__/EntityCard.test.tsx
@@ -3,149 +3,276 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import EntityCard from '../EntityCard';
 import { MythologicalEntity } from '../../types';
 
-// Mock VisualManifestation to simplify DOM and avoid lucide icon issues in test
 vi.mock('../VisualManifestation', () => ({
-    default: () => <div data-testid="visual-manifestation">Abstract Visual</div>
+  default: () => <div data-testid="visual-manifestation">Abstract Visual</div>,
 }));
 
-// Mock Data
-const mockEntity: MythologicalEntity = {
-    entity_type: 'Divinity',
-    name: 'TestEntity',
-    category: 'Test Category',
-    origin: { country: 'Test Country', ethnicity: 'Test Ethnicity', pantheon: 'Test Pantheon' },
-    identity: { gender: 'Male', cultural_role: 'Test Role', alignment: 'Neutral' },
-    attributes: { domains: ['Test Domain'], symbols: ['Test Symbol'], power_objects: [], symbolic_animals: [] },
-    appearance: { physical_signs: [], manifestations: 'Test', image_generation_prompt: 'A test prompt', imageUrl: '' }, // Empty imageUrl to show button
-    story: { description: 'Test Description', characteristics: [] },
-    relations: { parents: [], conjoint: [], descendants: [] },
-    rendering: {
-        images: {},
-        prompt_canon: 'Canon prompt',
-        prompt_variants: [
-            { style_id: 'regional_or_ethnic', prompt: 'Regional prompt', label: 'Regional' }
-        ]
-    }
+const buildEntity = (overrides: Partial<MythologicalEntity> = {}): MythologicalEntity => ({
+  entity_type: 'Divinity',
+  name: 'TestEntity',
+  category: 'Test Category',
+  origin: { country: 'Test Country', ethnicity: 'Test Ethnicity', pantheon: 'Test Pantheon' },
+  identity: { gender: 'Male', cultural_role: 'Test Role', alignment: 'Neutral' },
+  attributes: { domains: ['Test Domain'], symbols: ['Test Symbol'], power_objects: [], symbolic_animals: [] },
+  appearance: { physical_signs: [], manifestations: 'Test', image_generation_prompt: 'A test prompt', imageUrl: '' },
+  story: { description: 'Test Description', characteristics: [] },
+  relations: { parents: [], conjoint: [], descendants: [] },
+  rendering: {
+    images: {},
+    prompt_canon: 'Canon prompt',
+    prompt_variants: [
+      { style_id: 'regional_or_ethnic', prompt: 'Legacy regional prompt', label: 'Regional' },
+      { style_id: 'manga', prompt: 'Manga style prompt', label: 'Manga' },
+    ],
+  },
+  ...overrides,
+});
+
+const createJsonResponse = (body: unknown, init?: { ok?: boolean; status?: number }) => ({
+  ok: init?.ok ?? true,
+  status: init?.status ?? 200,
+  json: async () => body,
+});
+
+const createDeferredResponse = () => {
+  let resolve!: (value: ReturnType<typeof createJsonResponse>) => void;
+  const promise = new Promise<ReturnType<typeof createJsonResponse>>((nextResolve) => {
+    resolve = nextResolve;
+  });
+
+  return { promise, resolve };
 };
 
-describe('EntityCard Integration', () => {
-    // Mock global fetch
-    const mockFetch = vi.fn();
-    global.fetch = mockFetch;
+describe('EntityCard Smart UI', () => {
+  const mockFetch = vi.fn();
 
-    beforeEach(() => {
-        mockFetch.mockClear();
+  beforeEach(() => {
+    mockFetch.mockReset();
+    global.fetch = mockFetch as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('keeps photoreal generation flow unchanged', async () => {
+    mockFetch.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+
+      if (url.includes('/preview/TestEntity?style_id=regional_or_ethnic')) {
+        return createJsonResponse({ prompt: '' });
+      }
+
+      if (url === '/generate') {
+        return createJsonResponse({ status: 'success', image_url: '/generated/test.png' });
+      }
+
+      throw new Error(`Unexpected fetch call: ${url}`);
     });
 
-    it('should handle the generation flow: Button -> Loading -> Image', async () => {
-        render(<EntityCard data={mockEntity} />);
+    render(<EntityCard data={buildEntity()} />);
 
-        // 1. Verify Button is visible (since imageUrl is empty)
-        const generateBtn = screen.getByText(/Initialize Neural Render/i);
-        expect(generateBtn).toBeInTheDocument();
+    const generateBtn = screen.getByText(/Initialize Neural Render/i);
+    expect(generateBtn).toBeInTheDocument();
+    expect(screen.getByText('Manga')).toBeInTheDocument();
+    expect(screen.queryByText('Regional')).not.toBeInTheDocument();
 
-        // Setup successful mock response
-        mockFetch.mockResolvedValueOnce({
-            ok: true,
-            json: async () => ({ status: 'success', image_url: '/generated/test.png' }),
-        });
+    fireEvent.click(generateBtn);
 
-        // 2. Click Button
-        fireEvent.click(generateBtn);
-
-        // 3. Verify Loading State
-        // "Synthesizing from prompt..." is the text in the loading state
-        await waitFor(() => {
-            expect(screen.getByText(/Synthesizing from prompt/i)).toBeInTheDocument();
-        });
-
-        // 4. Verify Image Appears
-        // The image src should be the one from the mock
-        await waitFor(() => {
-            const img = screen.getByAltText('TestEntity');
-            expect(img).toBeInTheDocument();
-            expect(img).toHaveAttribute('src', '/generated/test.png');
-        });
+    await waitFor(() => {
+      expect(screen.getByText(/Synthesizing from prompt/i)).toBeInTheDocument();
     });
 
-    it('should reset to idle state when switching styles', async () => {
-        render(<EntityCard data={mockEntity} />);
+    await waitFor(() => {
+      expect(screen.getByAltText('TestEntity')).toHaveAttribute('src', '/generated/test.png');
+    });
+  });
 
-        // 1. Start with Photoreal (default) - Button should be visible
-        let generateBtn = screen.getByText(/Initialize Neural Render/i);
-        expect(generateBtn).toBeInTheDocument();
+  it('shows regional only when backend preview returns a prompt and ignores the legacy prompt', async () => {
+    mockFetch.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
 
-        // 2. Simulate generation completion (manually setting state via mock or just assuming start state)
-        // For this test, let's just assert that switching styles shows the button 
-        // even if we were in a different state, but since we can't easily inject state here without completing a flow:
+      if (url.includes('/preview/TestEntity?style_id=regional_or_ethnic')) {
+        return createJsonResponse({ prompt: 'Backend regional prompt' });
+      }
 
-        // Let's do a quick generation flow first
-        mockFetch.mockResolvedValueOnce({
-            ok: true,
-            json: async () => ({ status: 'success', image_url: '/generated/photoreal.png' }),
-        });
-
-        fireEvent.click(generateBtn);
-
-        await waitFor(() => {
-            expect(screen.getByAltText('TestEntity')).toHaveAttribute('src', '/generated/photoreal.png');
-        });
-
-        // 3. Switch Style to "Regional"
-        // Find the style selector. The component uses a StyleSelector. 
-        // We need to find how to trigger it. Based on the code, it renders options.
-        // Let's assume we can click on the text "Regional"
-        const regionalBtn = screen.getByText('Regional');
-        fireEvent.click(regionalBtn);
-
-        // 4. Verify "Initialize Neural Render" button is visible again
-        // Because "Regional" has no image in our mock data
-        await waitFor(() => {
-            expect(screen.getByText(/Initialize Neural Render/i)).toBeInTheDocument();
-        });
+      throw new Error(`Unexpected fetch call: ${url}`);
     });
 
-    it('should call onImageGenerated when generation succeeds', async () => {
-        const onImageGeneratedSpy = vi.fn();
+    render(<EntityCard data={buildEntity()} />);
 
-        // Setup mock response BEFORE action
-        mockFetch.mockResolvedValueOnce({
-            ok: true,
-            json: async () => ({ status: 'success', image_url: '/generated/callback_test.png' }),
-        });
-
-        render(<EntityCard data={mockEntity} onImageGenerated={onImageGeneratedSpy} />);
-
-        // 1. Click Generate
-        const generateBtn = screen.getByText(/Initialize Neural Render/i);
-        fireEvent.click(generateBtn);
-
-        // 3. Wait for Success
-        await waitFor(() => {
-            const img = screen.getByAltText('TestEntity');
-            expect(img).toBeInTheDocument();
-        });
-
-        // 4. Verify Callback
-        expect(onImageGeneratedSpy).toHaveBeenCalledWith('photoreal', '/generated/callback_test.png');
+    await waitFor(() => {
+      expect(screen.getByText('Regional')).toBeInTheDocument();
     });
 
-    it('should show generation button if image fails to load', async () => {
-        // Create entity with a "broken" image URL
-        const brokenEntity = { ...mockEntity, appearance: { ...mockEntity.appearance, imageUrl: '/broken/image.png' } };
+    fireEvent.click(screen.getByText('Regional'));
+    fireEvent.click(screen.getByText(/View GenAI Prompt/i));
 
-        render(<EntityCard data={brokenEntity} />);
-
-        // 1. Initially it should try to show the image (so button hidden)
-        const img = screen.getByAltText('TestEntity');
-        expect(img).toBeInTheDocument();
-
-        // 2. Trigger error on the image
-        fireEvent.error(img);
-
-        // 3. Expect button to appear
-        await waitFor(() => {
-            expect(screen.getByText(/Initialize Neural Render/i)).toBeInTheDocument();
-        });
+    await waitFor(() => {
+      expect(screen.getByText(/Backend regional prompt/i)).toBeInTheDocument();
     });
+
+    expect(screen.queryByText(/Legacy regional prompt/i)).not.toBeInTheDocument();
+  });
+
+  it('generates an image with regional_or_ethnic after backend preview confirms availability', async () => {
+    mockFetch.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (url.includes('/preview/TestEntity?style_id=regional_or_ethnic')) {
+        return createJsonResponse({ prompt: 'Backend regional prompt' });
+      }
+
+      if (url === '/generate') {
+        expect(init?.body).toBe(JSON.stringify({ entity_name: 'TestEntity', style_id: 'regional_or_ethnic' }));
+        return createJsonResponse({ status: 'success', image_url: '/generated/regional.png' });
+      }
+
+      throw new Error(`Unexpected fetch call: ${url}`);
+    });
+
+    render(<EntityCard data={buildEntity()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Regional')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Regional'));
+    fireEvent.click(screen.getByText(/Initialize Neural Render/i));
+
+    await waitFor(() => {
+      expect(screen.getByAltText('TestEntity')).toHaveAttribute('src', '/generated/regional.png');
+    });
+  });
+
+  it('hides regional when backend preview returns an empty prompt', async () => {
+    mockFetch.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+
+      if (url.includes('/preview/TestEntity?style_id=regional_or_ethnic')) {
+        return createJsonResponse({ prompt: '' });
+      }
+
+      throw new Error(`Unexpected fetch call: ${url}`);
+    });
+
+    render(<EntityCard data={buildEntity()} />);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalled();
+    });
+
+    expect(screen.queryByText('Regional')).not.toBeInTheDocument();
+    expect(screen.getByText('Manga')).toBeInTheDocument();
+  });
+
+  it('falls back to photoreal when a new entity does not support regional', async () => {
+    const firstEntity = buildEntity();
+    const secondEntity = buildEntity({
+      name: 'SecondEntity',
+      appearance: {
+        physical_signs: [],
+        manifestations: 'Second',
+        image_generation_prompt: 'Second fallback prompt',
+        imageUrl: '',
+      },
+      rendering: {
+        images: {},
+        prompt_canon: 'Second canon prompt',
+        prompt_variants: [
+          { style_id: 'regional_or_ethnic', prompt: 'Another legacy regional prompt', label: 'Regional' },
+          { style_id: 'manga', prompt: 'Second manga prompt', label: 'Manga' },
+        ],
+      },
+    });
+
+    mockFetch.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+
+      if (url.includes('/preview/TestEntity?style_id=regional_or_ethnic')) {
+        return createJsonResponse({ prompt: 'Backend regional prompt' });
+      }
+
+      if (url.includes('/preview/SecondEntity?style_id=regional_or_ethnic')) {
+        return createJsonResponse({ prompt: '' });
+      }
+
+      throw new Error(`Unexpected fetch call: ${url}`);
+    });
+
+    const { rerender } = render(<EntityCard data={firstEntity} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Regional')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Regional'));
+    fireEvent.click(screen.getByText(/View GenAI Prompt/i));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Backend regional prompt/i)).toBeInTheDocument();
+    });
+
+    rerender(<EntityCard data={secondEntity} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Regional')).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/Second canon prompt/i)).toBeInTheDocument();
+  });
+
+  it('ignores stale preview responses when the entity changes quickly', async () => {
+    const firstPreview = createDeferredResponse();
+    const firstEntity = buildEntity();
+    const secondEntity = buildEntity({
+      name: 'SecondEntity',
+      rendering: {
+        images: {},
+        prompt_canon: 'Second canon prompt',
+        prompt_variants: [
+          { style_id: 'regional_or_ethnic', prompt: 'Second legacy regional prompt', label: 'Regional' },
+          { style_id: 'manga', prompt: 'Second manga prompt', label: 'Manga' },
+        ],
+      },
+    });
+
+    mockFetch.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (url.includes('/preview/TestEntity?style_id=regional_or_ethnic')) {
+        return new Promise((resolve, reject) => {
+          const signal = init?.signal;
+
+          if (signal) {
+            signal.addEventListener('abort', () => {
+              reject(new DOMException('Aborted', 'AbortError'));
+            });
+          }
+
+          firstPreview.promise.then(resolve);
+        });
+      }
+
+      if (url.includes('/preview/SecondEntity?style_id=regional_or_ethnic')) {
+        return Promise.resolve(createJsonResponse({ prompt: '' }));
+      }
+
+      throw new Error(`Unexpected fetch call: ${url}`);
+    });
+
+    const { rerender } = render(<EntityCard data={firstEntity} />);
+
+    rerender(<EntityCard data={secondEntity} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Regional')).not.toBeInTheDocument();
+    });
+
+    firstPreview.resolve(createJsonResponse({ prompt: 'Stale backend regional prompt' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Regional')).not.toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
## What changed
- wired frontend availability of `regional_or_ethnic` to `/preview` instead of legacy static prompt variants
- kept the style hidden until backend preview confirms a non-empty prompt
- used the backend prompt in the prompt panel for `regional_or_ethnic`
- added stale-response protection with `AbortController`
- added a safe fallback to `photoreal` when a new entity does not support `regional_or_ethnic`
- added focused frontend tests for visibility, backend prompt usage, stale preview handling, fallback, and generation flow

## Why
`regional_or_ethnic` is now resolved by the backend through Style Matrix + PromptBuilder. The UI needed to reflect real backend availability without reimplementing style logic on the client.

## Validation
- `npx vitest run src/components/__tests__/EntityCard.test.tsx`
- `npm run build`